### PR TITLE
Open gRPC access

### DIFF
--- a/config/app.toml
+++ b/config/app.toml
@@ -174,7 +174,7 @@ enable = true
 address = "0.0.0.0:9091"
 
 # EnableUnsafeCORS defines if CORS should be enabled (unsafe - use it at your own risk).
-enable-unsafe-cors = false
+enable-unsafe-cors = true
 
 ###############################################################################
 ###                        State Sync Configuration                         ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     ports:
       - "26657:26657"
       - "1317:1317"
+      - "9090:9090"
+      - "9091:9091"
     command: terrad start
   oracle:
     image: terramoney/pseudo-feeder:bombay


### PR DESCRIPTION
grpc and grpc-web are already enabled, but the ports were not enabled in docker-compose file.