### PR TITLE
Update docker-compose.yml, remove version declaration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   terrad:
     build:


### PR DESCRIPTION
Removed deprecated `version` declaration which throws a warning when docker-compose up is run

Source: 
https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

Discussion:
https://github.com/docker/compose/issues/11628